### PR TITLE
Explicitly set character encoding

### DIFF
--- a/.settings/org.eclipse.core.resources.prefs
+++ b/.settings/org.eclipse.core.resources.prefs
@@ -1,0 +1,2 @@
+eclipse.preferences.version=1
+encoding/<project>=UTF-8

--- a/pom.xml
+++ b/pom.xml
@@ -17,8 +17,8 @@
       </plugin>
     </plugins>
   </build>
-  <properties>
-    <project.build.sourceEncoding>x-mswin-936</project.build.sourceEncoding>
-  </properties>
   <url>https://github.com/neo-project/neo-devpack-java</url>
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -17,5 +17,8 @@
       </plugin>
     </plugins>
   </build>
+  <properties>
+    <project.build.sourceEncoding>x-mswin-936</project.build.sourceEncoding>
+  </properties>
   <url>https://github.com/neo-project/neo-devpack-java</url>
 </project>

--- a/src/org/neo/smartcontract/framework/services/neo/Asset.java
+++ b/src/org/neo/smartcontract/framework/services/neo/Asset.java
@@ -1,4 +1,4 @@
-﻿package org.neo.smartcontract.framework.services.neo;
+package org.neo.smartcontract.framework.services.neo;
 
 import org.neo.smartcontract.framework.Syscall;
 

--- a/src/org/neo/smartcontract/framework/services/neo/Block.java
+++ b/src/org/neo/smartcontract/framework/services/neo/Block.java
@@ -1,4 +1,4 @@
-﻿package org.neo.smartcontract.framework.services.neo;
+package org.neo.smartcontract.framework.services.neo;
 
 import org.neo.smartcontract.framework.Syscall;
 

--- a/src/org/neo/smartcontract/framework/services/neo/Blockchain.java
+++ b/src/org/neo/smartcontract/framework/services/neo/Blockchain.java
@@ -1,4 +1,4 @@
-﻿package org.neo.smartcontract.framework.services.neo;
+package org.neo.smartcontract.framework.services.neo;
 
 import org.neo.smartcontract.framework.Syscall;
 

--- a/src/org/neo/smartcontract/framework/services/neo/Contract.java
+++ b/src/org/neo/smartcontract/framework/services/neo/Contract.java
@@ -1,4 +1,4 @@
-﻿package org.neo.smartcontract.framework.services.neo;
+package org.neo.smartcontract.framework.services.neo;
 
 import org.neo.smartcontract.framework.Syscall;
 

--- a/src/org/neo/smartcontract/framework/services/neo/Header.java
+++ b/src/org/neo/smartcontract/framework/services/neo/Header.java
@@ -1,4 +1,4 @@
-﻿package org.neo.smartcontract.framework.services.neo;
+package org.neo.smartcontract.framework.services.neo;
 
 import org.neo.smartcontract.framework.*;
 

--- a/src/org/neo/smartcontract/framework/services/neo/Storage.java
+++ b/src/org/neo/smartcontract/framework/services/neo/Storage.java
@@ -1,4 +1,4 @@
-﻿package org.neo.smartcontract.framework.services.neo;
+package org.neo.smartcontract.framework.services.neo;
 
 import java.math.BigInteger;
 import org.neo.smartcontract.framework.Syscall;

--- a/src/org/neo/smartcontract/framework/services/neo/StorageContext.java
+++ b/src/org/neo/smartcontract/framework/services/neo/StorageContext.java
@@ -1,4 +1,4 @@
-﻿package org.neo.smartcontract.framework.services.neo;
+package org.neo.smartcontract.framework.services.neo;
 
 public class StorageContext {
 }

--- a/src/org/neo/smartcontract/framework/services/neo/Transaction.java
+++ b/src/org/neo/smartcontract/framework/services/neo/Transaction.java
@@ -1,4 +1,4 @@
-﻿package org.neo.smartcontract.framework.services.neo;
+package org.neo.smartcontract.framework.services.neo;
 
 import org.neo.smartcontract.framework.*;
 

--- a/src/org/neo/smartcontract/framework/services/neo/TransactionAttribute.java
+++ b/src/org/neo/smartcontract/framework/services/neo/TransactionAttribute.java
@@ -1,4 +1,4 @@
-﻿package org.neo.smartcontract.framework.services.neo;
+package org.neo.smartcontract.framework.services.neo;
 
 import org.neo.smartcontract.framework.*;
 

--- a/src/org/neo/smartcontract/framework/services/neo/TransactionInput.java
+++ b/src/org/neo/smartcontract/framework/services/neo/TransactionInput.java
@@ -1,4 +1,4 @@
-﻿package org.neo.smartcontract.framework.services.neo;
+package org.neo.smartcontract.framework.services.neo;
 
 import org.neo.smartcontract.framework.*;
 

--- a/src/org/neo/smartcontract/framework/services/neo/TransactionOutput.java
+++ b/src/org/neo/smartcontract/framework/services/neo/TransactionOutput.java
@@ -1,4 +1,4 @@
-﻿package org.neo.smartcontract.framework.services.neo;
+package org.neo.smartcontract.framework.services.neo;
 
 import org.neo.smartcontract.framework.*;
 

--- a/src/org/neo/vm/_OpCode.java
+++ b/src/org/neo/vm/_OpCode.java
@@ -123,8 +123,8 @@ public enum _OpCode
     UNPACK(0xC2),
     PICKITEM(0xC3),
     SETITEM(0xC4),
-    NEWARRAY(0xC5), //ÓÃ×÷ÒýÓÃîÐÍ
-    NEWSTRUCT(0xC6); //ÓÃ×÷ÖµîÐÍ
+    NEWARRAY(0xC5), //ç”¨ä½œå¼•ç”¨é¡žåž‹
+    NEWSTRUCT(0xC6); //ç”¨ä½œå€¼é¡žåž‹
 
     
 	private int value;


### PR DESCRIPTION
There are some comments in the code which are written using the
specified character set. Without it, maven defaults to UTF-8 and
fails to compile the source files.